### PR TITLE
add a --package flag 

### DIFF
--- a/bin/ar2gostruct
+++ b/bin/ar2gostruct
@@ -29,6 +29,11 @@ OptionParser.new do |opt|
     ENV["model_dir"] = dir.to_s
   end
 
+  opt.on("--package pkgname", 
+         "package name so structs can be imported") do |p|
+    ENV["package"] = p.to_s
+  end
+
   opt.on("--require r", "require path") do |r|
     ENV["require_path"] = r.to_s
   end

--- a/lib/ar2gostruct/gostruct.rb
+++ b/lib/ar2gostruct/gostruct.rb
@@ -3,6 +3,7 @@ module Ar2gostruct
     def initialize(model_dir)
       @model_dir = model_dir
       get_models
+      puts "package #{ENV["package"]}\n\n" unless ENV["package"].blank?
     end
     attr_accessor :model_dir, :models
 


### PR DESCRIPTION
This writes a package name at the beginning of the output. Now I can take the output of ar2gostruct and import it into my go code without any manual steps (except maybe adding imports as required for types in the structs).
